### PR TITLE
Fix: Make Kafka SSL configuration optional

### DIFF
--- a/plugins/kafka-as-datasource-as-eventsource/package-lock.json
+++ b/plugins/kafka-as-datasource-as-eventsource/package-lock.json
@@ -1,12 +1,12 @@
 {
         "name": "@godspeedsystems/plugins-kafka-as-datasource-as-eventsource",
-        "version": "1.0.1",
+        "version": "1.0.6",
         "lockfileVersion": 3,
         "requires": true,
         "packages": {
                 "": {
                         "name": "@godspeedsystems/plugins-kafka-as-datasource-as-eventsource",
-                        "version": "1.0.1",
+                        "version": "1.0.6",
                         "license": "Godspeed License 1.0",
                         "dependencies": {
                                 "@godspeedsystems/core": "latest",

--- a/plugins/kafka-as-datasource-as-eventsource/package.json
+++ b/plugins/kafka-as-datasource-as-eventsource/package.json
@@ -1,6 +1,6 @@
 {
         "name": "@godspeedsystems/plugins-kafka-as-datasource-as-eventsource",
-        "version": "1.0.6",
+        "version": "1.0.7",
         "description": "kafka as datasource-as-eventsource plugin for Godspeed Framework",
         "publishConfig": {
                 "access": "public"


### PR DESCRIPTION
Fix: Make Kafka SSL configuration optional

The Kafka plugin was failing to initialize when SSL configuration was not provided by the user. This was due to the plugin attempting to access properties like `ssl.reject`, `ssl.key`, etc., even when the `ssl` object itself was undefined.  This resulted in a "cannot read properties of undefined (reading 'reject')" error.

This commit addresses this issue by making the SSL configuration optional.  The plugin now checks if the `ssl` configuration exists before attempting to access its properties.  
If the `ssl` object is not provided, the plugin will initialize the Kafka client without SSL.  If the `ssl` object *is* provided, it will read the `key`, `cert`, and `ca` files (if provided) and use them to configure SSL.  The `rejectUnauthorized` option defaults to `false` if not explicitly set.

This change ensures that the Kafka plugin can be initialized successfully regardless of whether SSL configuration is provided, making it more robust and user-friendly.  Users can now choose to configure SSL only when necessary.