### PR TITLE
fix: release 1.0.32 add exception handling

### DIFF
--- a/plugins/express-as-http/package.json
+++ b/plugins/express-as-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@godspeedsystems/plugins-express-as-http",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "publishConfig": {
     "access": "public"
   },

--- a/plugins/express-as-http/src/index.ts
+++ b/plugins/express-as-http/src/index.ts
@@ -265,15 +265,28 @@ export default class EventSource extends GSEventSource {
     const app: express.Express = this.client as express.Express;
     //@ts-ignore
     app[httpMethod](fullUrl, this.authnHOF(event.authn), async (req: express.Request, res: express.Response) => {
-      const gsEvent: GSCloudEvent = createGSEvent(req, endpoint)
-      const status: GSStatus = await processEvent(gsEvent, { key: eventRoute, ...eventConfig });
-      if (status.code && status.code === 302 && status.data?.redirectUrl) {
-        res.redirect(302, status.data.redirectUrl);
-      } else {
-      res
-        .status(status.code || 200)
-        // if data is a integer, it takes it as statusCode, so explicitly converting it to string
-        .send(Number.isInteger(status.data) ? String(status.data) : status.data);
+      try {
+        const gsEvent: GSCloudEvent = createGSEvent(req, endpoint);
+        const status: GSStatus = await processEvent(gsEvent, { key: eventRoute, ...eventConfig });
+
+        if (status.code && status.data?.redirectUrl && status.code === 302) {
+          res.redirect(302, status.data.redirectUrl);
+        } else {
+          res
+            .status(status.code || 200)
+            // if data is a integer, it takes it as statusCode, so explicitly converting it to string
+            .send( 
+              Number.isInteger(status.data)
+                ? String(status.data)
+                : status.data
+            );
+        }
+      } catch (err) {
+        console.error("Unhandled error in API handler:", err);
+        res.status(500).json({
+          error: "Internal server error during request handling.",
+          details: err instanceof Error ? err.message : err,
+        });
       }
     });
     return Promise.resolve();


### PR DESCRIPTION
# Add Top-Level Error Handling to processEvent

This PR adds a top-level try-catch block to the Express plugin's route handler in the Godspeed framework. This ensures that any unexpected runtime errors during request handling are caught and handled gracefully, preventing the process from crashing and avoiding unnecessary Kubernetes pod restarts.

## Changes Made
Wrapped the entire request handler in a try-catch block
Logged internal errors to the server console
Returned a consistent 500 response with error details for debugging